### PR TITLE
Updating the link to the CLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Meta-info on the CSC organization
 
 * [Wiki](https://github.com/csc/csc-open-source/wiki)
 * [Issues](https://github.com/csc/csc-open-source/wiki)
-* [CLA (Contributor License Agreement)](http://clahubdemo.herokuapp.com/agreements/csc/csc-open-source)
+* [CLA (Contributor License Agreement)]http://opensource.csc.com/sysworkflow/en/neoclassic/251810809537eb36f73ac23031915862/Signing_CLA_Welcome_Page.php)
 
 Our CLA is minimally different than the [Individual Contributor License Agreement ("Agreement") V2.0](http://www.apache.org/licenses/icla.txt)


### PR DESCRIPTION
Opened due to the link possibly pointing to a dev instance of the CLA app... csc/Hanlon#191
