### PR TITLE
Updated branding for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ DXC Technology Open Source
 
 Meta-info on the DXC Technology organization
 
-* [Wiki](https://github.com/dxc-technology/csc-open-source/wiki)
-* [Issues](https://github.com/dxc-technology/csc-open-source/issues)
+* [Wiki](https://github.com/dxc-technology/dxc-open-source/wiki)
+* [Issues](https://github.com/dxc-technology/dxc-open-source/issues)
 * [CLA (Contributor License Agreement)](http://opensource.dxc.com/sysworkflow/en/neoclassic/251810809537eb36f73ac23031915862/Signing_CLA_Welcome_Page.php)
 
 Our CLA is minimally different than the [Individual Contributor License Agreement ("Agreement") V2.0](http://www.apache.org/licenses/icla.txt)


### PR DESCRIPTION
Readme contained CSC named links, even though the repository was using a DXC names in folder structure